### PR TITLE
Memperbaiki hyperlink dokumen yang salah menunjuk halaman abstrak

### DIFF
--- a/ta-its.cls
+++ b/ta-its.cls
@@ -291,6 +291,7 @@
 % Environment
 % abstrak
 \newenvironment{abstrak}{
+\cleardoublepage\phantomsection
 \addcontentsline{toc}{chapter}{ABSTRAK}
 \begin{centering}
 \textbf{\MakeUppercase{\judul}} \\*[11pt]%
@@ -311,6 +312,7 @@ Pembimbing I  & : \pembimbingSatu
 
 % abstract
 \newenvironment{abstract}{
+\cleardoublepage\phantomsection
 \addcontentsline{toc}{chapter}{ABSTRACT}
 \begin{centering}
 \textbf{\MakeUppercase{\judulEnglish}} \\*[11pt]%


### PR DESCRIPTION
Hyperlink dokumen salah menunjuk halaman abstrak saat memilih halaman tersebut pada daftar isi dan pdf index/bookmark. Perbaikan diimplementasikan pada halaman abstrak bahasa Indonesia dan bahasa Inggris.
